### PR TITLE
Update modules mvids before rewriting an assembly

### DIFF
--- a/Source/Smocks/IL/AssemblyRewriter.cs
+++ b/Source/Smocks/IL/AssemblyRewriter.cs
@@ -123,7 +123,9 @@ namespace Smocks.IL
             };
 
             foreach (var module in assembly.Modules)
-              module.Mvid = Guid.NewGuid();
+            {
+                module.Mvid = Guid.NewGuid();                
+            }
 
             assembly.Write(outputPath, writerParameters);
 

--- a/Source/Smocks/IL/AssemblyRewriter.cs
+++ b/Source/Smocks/IL/AssemblyRewriter.cs
@@ -122,6 +122,9 @@ namespace Smocks.IL
                 WriteSymbols = hasSymbols
             };
 
+            foreach (var module in assembly.Modules)
+              module.Mvid = Guid.NewGuid();
+
             assembly.Write(outputPath, writerParameters);
 
             _rewrittenAssemblies.Add(outputPath);


### PR DESCRIPTION
When we modify an assembly we should also update its mvid. Otherwise some coverage/profiling tools can be confused by having different assemblies with similar mvids. Please see, for instance: https://dotnettools-support.jetbrains.com/hc/en-us/community/posts/205988489-Unit-Testing-works-but-dotCover-failes-to-run-test-Unrecoverable-Error